### PR TITLE
chore: add CODEOWNERS (@TITManagement)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @TITManagement


### PR DESCRIPTION
Add CODEOWNERS to enforce reviewer ownership.